### PR TITLE
Fix two `SyntaxWarning` issues

### DIFF
--- a/generator/templates/args_types.ji
+++ b/generator/templates/args_types.ji
@@ -86,7 +86,7 @@ class {{ class_name }}:
             {{ field_name }}: {{ py_map[field_type] }} = {{ init_map[py_map[field_type]]}},
         {% endfor %}
         ):
-            """
+            r"""
             Args:
         {% for field in struct_fields %}
             {% set field_type = field.0 %}
@@ -109,7 +109,7 @@ class {{ class_name }}:
     @property
     def {{ field_name }}(self) -> {{ py_map[field_type] }}:
         {% if field.3 %}
-        """{{ "\n        ".join(field.3) }}
+        r"""{{ "\n        ".join(field.3) }}
         """
         {% endif %}
         {% if field_type in blit_types %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,5 +31,8 @@ addopts = "-ra -q"
 testpaths = [
     "tests"
 ]
+filterwarnings = [
+    "error",
+]
 log_cli = true
 log_cli_level = "INFO"


### PR DESCRIPTION
When running the test suite, these two warnings popped up:

```
lore/types/args.py:3276
  SyntaxWarning: "\`" is an invalid escape sequence.
  Such sequences will not work in the future.
  Did you mean "\\`"? A raw string is also an option.

    source_path (str): Source path within the linked repository; `/` or `\` means the root

lore/types/args.py:3309
  SyntaxWarning: "\`" is an invalid escape sequence.
  Such sequences will not work in the future.
  Did you mean "\\`"? A raw string is also an option.

    """Source path within the linked repository; `/` or `\` means the root"""
```

These are resolved by updating the Jinja template to use r-strings, which prevents interpretation of the backslash-backtick escapes.

In addition, pytest is now configured to escalate warnings to errors. This should prevent such issues from silently cropping up again.
